### PR TITLE
Add Careers link to header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import Logo from '../images/logo.svg'
 
 export const requestADemoHref = 'mailto:contact@indigov.us'
+export const careersHref = 'https://jobs.lever.co/indigov'
 
 const Header = () => (
   <header className='sticky top-0 py-8 bg-white w-full z-10'>
@@ -25,6 +26,12 @@ const Header = () => (
             <Link className='montserrat uppercase tracking-widest text-sm' to='/about' activeClassName='font-bold border-b-2'>
               About
             </Link>
+          </div>
+
+          <div className='px-6'>
+            <a className='montserrat uppercase tracking-widest text-sm' href={careersHref}>
+              Careers
+            </a>
           </div>
 
           <div className='px-6'>


### PR DESCRIPTION
add "careers" to top menu options so we can convert more engineers who google Indigov after seeing our recent press

<img width="1503" alt="Screen Shot 2021-07-19 at 5 49 31 PM" src="https://user-images.githubusercontent.com/1400364/126246189-9a1753b5-484c-4a39-8117-616efa6d0fed.png">
